### PR TITLE
Instead of an attribute list like "PREF;WORK;FAX", the OSX contacts a…

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -85,7 +85,7 @@ class VCard
     ) {
         // init value
         $value = $name . ';' . $extended . ';' . $street . ';' . $city . ';' . $region . ';' . $zip . ';' . $country;
-
+        $type = $this->transformTypes($type);
         // set property
         $this->setProperty(
             'address',
@@ -146,9 +146,10 @@ class VCard
      */
     public function addEmail($address, $type = '')
     {
+        $type = $this->transformTypes($type);
         $this->setProperty(
             'email',
-            'EMAIL;INTERNET' . (($type != '') ? ';' . $type : ''),
+            'EMAIL;type=INTERNET' . (($type != '') ? ';' . $type : ''),
             $address
         );
 
@@ -292,6 +293,7 @@ class VCard
      */
     public function addPhoneNumber($number, $type = '')
     {
+        $type = $this->transformTypes($type);
         $this->setProperty(
             'phoneNumber',
             'TEL' . (($type != '') ? ';' . $type : ''),
@@ -329,6 +331,7 @@ class VCard
      */
     public function addURL($url, $type = '')
     {
+        $type = $this->transformTypes($type);
         $this->setProperty(
             'url',
             'URL' . (($type != '') ? ';' . $type : ''),
@@ -662,7 +665,8 @@ class VCard
      * @param  string $element The element name you want to set, f.e.: name, email, phoneNumber, ...
      * @param  string $key
      * @param  string $value
-     * @return void
+     *
+     * @throws Exception
      */
     private function setProperty($element, $key, $value)
     {
@@ -696,5 +700,25 @@ class VCard
         $version = isset($matches[1]) ? ((int) $matches[1]) : 999;
 
         return ($version < 8);
+    }
+
+    /**
+     * Takes type(s) string like "PREF;WORK;FAX" and adds "type=" to each type property.
+     *
+     * @param string $types
+     *
+     * @return string
+     */
+    protected function transformTypes($types)
+    {
+        if ($types == '') {
+            return $types;
+        }
+
+        $types = explode(';', $types);
+        foreach ($types as $key => $type) {
+            $types[$key] = 'type=' . $type;
+        }
+        return implode(';', $types);
     }
 }

--- a/tests/VCardTest.php
+++ b/tests/VCardTest.php
@@ -55,7 +55,7 @@ class VCardTest extends \PHPUnit_Framework_TestCase
         $this->additional = '&';
         $this->prefix = 'Mister';
         $this->suffix = 'Junior';
-        
+
         $this->emailAddress1 = '';
         $this->emailAddress2 = '';
 
@@ -169,11 +169,16 @@ class VCardTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        foreach ($emails as $key => $email) {
-            if (is_string($key)) {
-                $this->assertContains('EMAIL;INTERNET;' . $key . ':' . $email, $this->vcard->getOutput());
+        foreach ($emails as $types => $email) {
+            if (is_string($types)) {
+                $types = explode(';', $types);
+                foreach ($types as $key => $type) {
+                    $types[$key] = 'type=' . $type;
+                }
+                $types = implode(';', $types);
+                $this->assertContains('EMAIL;type=INTERNET;' . $types . ':' . $email, $this->vcard->getOutput());
             } else {
-                $this->assertContains('EMAIL;INTERNET:' . $email, $this->vcard->getOutput());
+                $this->assertContains('EMAIL;type=INTERNET:' . $email, $this->vcard->getOutput());
             }
         }
     }


### PR DESCRIPTION
…pp expects a list like that: "type=PREF;type=WORK;type=FAX". To be compatible to this format, I added a little bit of code to transform it like that.
